### PR TITLE
Different collections for different tenants.

### DIFF
--- a/app/models/concerns/account_scoped.rb
+++ b/app/models/concerns/account_scoped.rb
@@ -1,16 +1,26 @@
 module AccountScoped
   extend ActiveSupport::Concern
   included do
+
+    store_in collection: Proc.new { tenant_collection_name }
+
     belongs_to :account, class_name: Account.to_s, inverse_of: nil
 
     before_validation { self.account = Account.current unless self.account }
-    default_scope -> { where(Account.current ? {account: Account.current} : {}) }
+    default_scope -> { with(collection: tenant_collection_name).where(Account.current ? {account: Account.current} : {}) }
+
   end
 
   module ClassMethods
 
     def validates_account_uniqueness_of(field)
       validates field, uniqueness: { scope: :account_id }
+    end
+
+    def tenant_collection_name
+      name = to_s.collectionize
+      name = "acc#{Account.current.id}_#{name}" if Account.current.present?
+      name
     end
   end
 end

--- a/app/models/setup/cenit_unscoped.rb
+++ b/app/models/setup/cenit_unscoped.rb
@@ -5,7 +5,7 @@ module Setup
     include Mongoid::Document
     include Mongoid::Timestamps
     include Mongoid::CenitExtension
-    include Trackable
+    #include Trackable
 
     included do
       Setup::Models.regist(self)

--- a/app/models/setup/shared_collection.rb
+++ b/app/models/setup/shared_collection.rb
@@ -1,6 +1,7 @@
 module Setup
   class SharedCollection
     include CenitUnscoped
+    include Trackable
 
     Setup::Models.exclude_actions_for self, :new
 

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -104,9 +104,9 @@ RailsAdmin.config do |config|
 
       field :_id
       field :created_at
-      field :creator
+      #field :creator
       field :updated_at
-      field :updater
+      #field :updater
     end
 
     fields :name, :schemas
@@ -149,9 +149,9 @@ RailsAdmin.config do |config|
 
       field :_id
       field :created_at
-      field :creator
+      #field :creator
       field :updated_at
-      field :updater
+      #field :updater
     end
     fields :library, :uri, :schema
   end
@@ -218,9 +218,9 @@ RailsAdmin.config do |config|
 
       field :_id
       field :created_at
-      field :creator
+      #field :creator
       field :updated_at
-      field :updater
+      #field :updater
     end
     fields :schema, :name, :used_memory
   end
@@ -285,9 +285,9 @@ RailsAdmin.config do |config|
 
       field :_id
       field :created_at
-      field :creator
+      #field :creator
       field :updated_at
-      field :updater
+      #field :updater
     end
 
     fields :name, :url, :webhooks, :parameters, :headers, :key, :token
@@ -323,9 +323,9 @@ RailsAdmin.config do |config|
 
       field :_id
       field :created_at
-      field :creator
+      #field :creator
       field :updated_at
-      field :updater
+      #field :updater
     end
     fields :name, :connections
   end
@@ -360,9 +360,9 @@ RailsAdmin.config do |config|
 
       field :_id
       field :created_at
-      field :creator
+      #field :creator
       field :updated_at
-      field :updater
+      #field :updater
     end
     fields :name, :purpose, :path, :method, :parameters, :headers
   end
@@ -383,9 +383,9 @@ RailsAdmin.config do |config|
 
       field :_id
       field :created_at
-      field :creator
+      #field :creator
       field :updated_at
-      field :updater
+      #field :updater
     end
     fields :flow, :retries, :response, :exception_message
   end
@@ -481,9 +481,9 @@ RailsAdmin.config do |config|
 
       field :_id
       field :created_at
-      field :creator
+      #field :creator
       field :updated_at
-      field :updater
+      #field :updater
     end
 
     fields :name, :event, :translator
@@ -500,9 +500,9 @@ RailsAdmin.config do |config|
 
       field :_id
       field :created_at
-      field :creator
+      #field :creator
       field :updated_at
-      field :updater
+      #field :updater
     end
 
     fields :name, :last_trigger_timestamps
@@ -539,9 +539,9 @@ RailsAdmin.config do |config|
 
       field :_id
       field :created_at
-      field :creator
+      #field :creator
       field :updated_at
-      field :updater
+      #field :updater
     end
 
     fields :name, :data_type, :triggers, :last_trigger_timestamps
@@ -591,9 +591,9 @@ RailsAdmin.config do |config|
 
       field :_id
       field :created_at
-      field :creator
+      #field :creator
       field :updated_at
-      field :updater
+      #field :updater
     end
 
     fields :name, :scheduling_method, :expression, :last_trigger_timestamps
@@ -708,9 +708,9 @@ RailsAdmin.config do |config|
 
       field :_id
       field :created_at
-      field :creator
+      #field :creator
       field :updated_at
-      field :updater
+      #field :updater
     end
 
     fields :name, :type, :style, :transformation
@@ -754,7 +754,7 @@ RailsAdmin.config do |config|
       field :parameter
 
       field :created_at
-      field :creator
+      #field :creator
       field :updated_at
     end
     fields :label, :parameter
@@ -775,9 +775,9 @@ RailsAdmin.config do |config|
 
       field :_id
       field :created_at
-      field :creator
+      #field :creator
       field :updated_at
-      field :updater
+      #field :updater
     end
     fields :name, :libraries, :translators, :connections, :webhooks, :connection_roles, :flows, :events
   end


### PR DESCRIPTION
Be sure to export your tenant data before merging these commits since these changes make inaccessible the data stored in the default database collections.