### PR TITLE
Upgrading MongoDB to 3.0: rescue from querying collection indexes

### DIFF
--- a/app/models/setup/schema_data_type.rb
+++ b/app/models/setup/schema_data_type.rb
@@ -11,13 +11,17 @@ module Setup
       if schema_changed?
         unique_properties = records_model.unique_properties
         indexed_properties = []
-        records_model.collection.indexes.each do |index|
-          next if (indexed_property = index['key'].keys.first) == '_id'
-          if unique_properties.detect { |p| p == indexed_property }
-            indexed_properties << indexed_property
-          else
-            records_model.collection.indexes.drop_one(index['name'])
+        begin
+          records_model.collection.indexes.each do |index|
+            next if (indexed_property = index['key'].keys.first) == '_id'
+            if unique_properties.detect { |p| p == indexed_property }
+              indexed_properties << indexed_property
+            else
+              records_model.collection.indexes.drop_one(index['name'])
+            end
           end
+        rescue
+          # Mongo driver raises an exception if the collection does not exists, nothing to worry about
         end
         unique_properties.reject { |p| indexed_properties.include?(p) }.each do |p|
           begin

--- a/lib/edi/formater.rb
+++ b/lib/edi/formater.rb
@@ -80,7 +80,8 @@ module Edi
 
     def ns_for(ns, namespaces)
       letters = true
-      ns = ns.split(':').last.underscore.split('_').collect { |token| (letters &&= token[0] =~ /[[:alpha:]]/) ? token[0] : '' }.join
+      ns = ns.split(':').last.split('/').last.underscore.split('_').collect { |token| (letters &&= token[0] =~ /[[:alpha:]]/) ? token[0] : '' }.join
+      ns = 'ns' if ns.blank?
       if namespaces.values.include?(ns)
         i = 1
         while namespaces.values.include?(nns = ns + i.to_s)

--- a/lib/edi/formater.rb
+++ b/lib/edi/formater.rb
@@ -45,7 +45,7 @@ module Edi
     def to_xml(options = {})
       element = to_xml_element(options)
       options[:xml_doc] << element
-      options[:xml_doc].to_xml
+      options[:xml_doc].to_xml(options)
     end
 
     alias_method :inspect_json, :to_hash

--- a/lib/mongoff/association.rb
+++ b/lib/mongoff/association.rb
@@ -34,7 +34,7 @@ module Mongoff
     end
 
     def foreign_key
-      nested? ? nil : model.attribute_key(name)
+      nested? ? nil : model.attribute_key(name).to_s
     end
   end
 end

--- a/lib/mongoff/model.rb
+++ b/lib/mongoff/model.rb
@@ -207,9 +207,9 @@ module Mongoff
     def attribute_key(field, field_metadata = {})
       if (field_metadata[:model] ||= property_model(field)) &&
         (schema = (field_metadata[:schema] ||= property_schema(field)))['referenced']
-        return "#{field}_id" + ('s' if schema['type'] == 'array').to_s
+        return ("#{field}_id" + (schema['type'] == 'array' ? 's' : '')).to_sym
       end
-      field.to_s == 'id' ? :_id : field
+      field.to_s == 'id' ? :_id : field.to_sym
     end
 
     def to_string(value)

--- a/lib/mongoff/record.rb
+++ b/lib/mongoff/record.rb
@@ -295,7 +295,6 @@ module Mongoff
       @fields.each do |field, value|
         nested = (association = orm_model.associations[field]) && association.nested?
         if nested || document[field].nil?
-          nested = (association = orm_model.associations[field]) && association.nested?
           attribute_key = orm_model.attribute_key(field)
           if value.is_a?(RecordArray)
             document[attribute_key] = value.collect { |v| nested ? v.attributes : v.id }


### PR DESCRIPTION
Rescue from querying collection indexes when the collection doesn't exists